### PR TITLE
Return value from Numeric validator

### DIFF
--- a/messages.go
+++ b/messages.go
@@ -11,7 +11,7 @@ var (
 	MessageLenShorter = "must be shorter than %d characters"
 	MessageExclude    = "cannot be ‘%s’"
 	MessageInclude    = "must be one of ‘%s’"
-	MessageNumeric    = "must be a whole number"
+	MessageInteger    = "must be a whole number"
 	MessageDate       = "must be a date as ‘%s’"
 )
 

--- a/validate.go
+++ b/validate.go
@@ -269,14 +269,13 @@ func (v *Validator) Len(key, value string, min, max int, message ...string) {
 	}
 }
 
-// Numeric checks if this looks like a numeric value.
-//
-// Right now this accepts while integers only; both positive and negative.
-func (v *Validator) Numeric(key, value string, message ...string) {
-	_, err := strconv.ParseInt(value, 10, 64)
+// Integer checks if this looks like an integer (i.e. a whole number).
+func (v *Validator) Integer(key, value string, message ...string) int64 {
+	i, err := strconv.ParseInt(strings.TrimSpace(value), 10, 64)
 	if err != nil {
-		v.Append(key, getMessage(message, MessageNumeric))
+		v.Append(key, getMessage(message, MessageInteger))
 	}
+	return i
 }
 
 // Date checks if the string looks like a date in the given layout.

--- a/validate_test.go
+++ b/validate_test.go
@@ -511,29 +511,40 @@ func TestHexColor(t *testing.T) {
 	}
 }
 
-func TestNumeric(t *testing.T) {
+func TestInteger(t *testing.T) {
 	cases := []struct {
-		val            func(Validator)
+		val            func(Validator) int64
+		want           int64
 		expectedErrors map[string][]string
 	}{
 		{
-			func(v Validator) { v.Numeric("k", "1") },
+			func(v Validator) int64 { return v.Integer("k", "6") },
+			6,
 			make(map[string][]string),
 		},
 		{
-			func(v Validator) { v.Numeric("k", "0") },
+			func(v Validator) int64 { return v.Integer("k", " 6 ") },
+			6,
 			make(map[string][]string),
 		},
 		{
-			func(v Validator) { v.Numeric("k", "-1") },
+			func(v Validator) int64 { return v.Integer("k", "0") },
+			0,
 			make(map[string][]string),
 		},
 		{
-			func(v Validator) { v.Numeric("k", "1.2") },
+			func(v Validator) int64 { return v.Integer("k", "-1") },
+			-1,
+			make(map[string][]string),
+		},
+		{
+			func(v Validator) int64 { return v.Integer("k", "1.2") },
+			0,
 			map[string][]string{"k": {"must be a whole number"}},
 		},
 		{
-			func(v Validator) { v.Numeric("k", "asd") },
+			func(v Validator) int64 { return v.Integer("k", "asd") },
+			0,
 			map[string][]string{"k": {"must be a whole number"}},
 		},
 	}
@@ -541,10 +552,14 @@ func TestNumeric(t *testing.T) {
 	for i, tc := range cases {
 		t.Run(fmt.Sprintf("%v", i), func(t *testing.T) {
 			v := New()
-			tc.val(v)
+			i := tc.val(v)
 
 			if !reflect.DeepEqual(v.Errors, tc.expectedErrors) {
 				t.Errorf("\nout:      %#v\nexpected: %#v\n", v.Errors, tc.expectedErrors)
+			}
+
+			if i != tc.want {
+				t.Errorf("\nout:      %#v\nexpected: %#v\n", i, tc.want)
 			}
 		})
 	}


### PR DESCRIPTION
Also rename it to "Integer", as that's a bit clearer. I copied the
"numeric" name from Rails where it makes sense since you can also use
floats, but in Go it probably makes less sense.

Useful for:
https://github.com/Teamwork/desk/pull/3210#discussion_r173005279

Also call strings.TrimSpace on the value, otherwise e.g. `" 6"` will be
confusing.
