### PR TITLE
Add Validator.Nil()

### DIFF
--- a/validate.go
+++ b/validate.go
@@ -79,6 +79,25 @@ func (v *Validator) HasErrors() bool {
 	return len(v.Errors) > 0
 }
 
+// ErrorOrNil returns nil if there are no errors, or the Validator object if there are.
+//
+// This makes it a bit more elegant to return from a function:
+//
+//   if v.HasErrors() {
+//       return v
+//   }
+//   return nil
+//
+// Can now be:
+//
+//   return v.ErrorOrNil()
+func (v *Validator) ErrorOrNil() error {
+	if v.HasErrors() {
+		return v
+	}
+	return nil
+}
+
 // Merge errors from another validator in to this one.
 func (v *Validator) Merge(other Validator) {
 	for k, val := range other.Errors {

--- a/validate_test.go
+++ b/validate_test.go
@@ -529,3 +529,26 @@ func TestBoolean(t *testing.T) {
 		})
 	}
 }
+
+func TestErrorOrNil(t *testing.T) {
+	cases := []struct {
+		in   *Validator
+		want error
+	}{
+		{&Validator{}, nil},
+		{&Validator{Errors: map[string][]string{}}, nil},
+		{
+			&Validator{Errors: map[string][]string{"x": []string{"X"}}},
+			&Validator{Errors: map[string][]string{"x": []string{"X"}}},
+		},
+	}
+
+	for i, tc := range cases {
+		t.Run(fmt.Sprintf("%v", i), func(t *testing.T) {
+			got := tc.in.ErrorOrNil()
+			if !reflect.DeepEqual(got, tc.want) {
+				t.Errorf("\nout:  %#v\nwant: %#v\n", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This makes it a bit more elegant to return from a function:

	if v.HasErrors() {
		return v
	}
	return nil

Can now be:

	return v.Nil()

Not 100% sure about the name `Nil()` though. The multierrors package has `ErrorOrNil()`, so could follow that and use `ValidatorOrNil()`, but I thought that was a bit of a mouthful. `Return()` might also be a good name?