### PR TITLE
validate URL with path and scheme

### DIFF
--- a/messages.go
+++ b/messages.go
@@ -4,6 +4,7 @@ package validate
 var (
 	MessageRequired   = "must be set"
 	MessageDomain     = "must be a valid domain"
+	MessageURL        = "must be a valid url"
 	MessageEmail      = "must be a valid email address"
 	MessageIPv4       = "must be a valid IPv4 address"
 	MessageHexColor   = "must be a valid color code"

--- a/validate_test.go
+++ b/validate_test.go
@@ -264,6 +264,48 @@ func TestValidators(t *testing.T) {
 			map[string][]string{"v": {"must be a valid domain"}},
 		},
 
+		// URL
+		{
+			func(v Validator) { v.URL("v", "") },
+			make(map[string][]string),
+		},
+		{
+			func(v Validator) { v.URL("v", "example.com") },
+			make(map[string][]string),
+		},
+		{
+			func(v Validator) { v.URL("v", "example.com.test.asd/testing.html") },
+			make(map[string][]string),
+		},
+		{
+			func(v Validator) { v.URL("v", "example-test.com") },
+			make(map[string][]string),
+		},
+		{
+			func(v Validator) { v.URL("v", "ﻢﻔﺗﻮﺣ.ﺬﺑﺎﺑﺓ") },
+			make(map[string][]string),
+		},
+		{
+			func(v Validator) { v.URL("v", "xn--pgbg2dpr.xn--mgbbbe5a") },
+			make(map[string][]string),
+		},
+		{
+			func(v Validator) { v.URL("v", "one-label") },
+			map[string][]string{"v": {"must be a valid domain"}},
+		},
+		{
+			func(v Validator) { v.URL("v", "one-label", "foo") },
+			map[string][]string{"v": {"foo"}},
+		},
+		{
+			func(v Validator) { v.URL("v", "example.com:-)") },
+			map[string][]string{"v": {"no host given: example.com:-)"}},
+		},
+		{
+			func(v Validator) { v.URL("v", "ex ample.com") },
+			map[string][]string{"v": {"must be a valid url: parse http://ex%20ample.com: invalid URL escape \"%20\""}},
+		},
+
 		// HexColor
 		{
 			func(v Validator) { v.HexColor("v", "") },


### PR DESCRIPTION
Validating the domain is a bit too strict for some purposes when we want to accept an optional path, optional scheme and host.