### PR TITLE
Fix false positive for empty int64

### DIFF
--- a/validate.go
+++ b/validate.go
@@ -201,8 +201,20 @@ func (v *Validator) Required(key string, value interface{}, message ...string) {
 		if strings.TrimSpace(val) == "" {
 			v.Append(key, msg)
 		}
-	case int, int64, uint, uint64:
-		if val == 0 {
+	case int:
+		if val == int(0) {
+			v.Append(key, msg)
+		}
+	case int64:
+		if int64(val) == int64(0) {
+			v.Append(key, msg)
+		}
+	case uint:
+		if val == uint(0) {
+			v.Append(key, msg)
+		}
+	case uint64:
+		if val == uint64(0) {
 			v.Append(key, msg)
 		}
 	case bool:

--- a/validate_test.go
+++ b/validate_test.go
@@ -11,6 +11,33 @@ import (
 	"github.com/teamwork/mailaddress"
 )
 
+func TestRequiredInt(t *testing.T) {
+	tests := []struct {
+		a    interface{}
+		want bool
+	}{
+		{0, true},
+		{int64(0), true},
+		{uint(0), true},
+		{uint64(0), true},
+		{1, false},
+		{int64(1), false},
+		{uint(1), false},
+		{uint64(1), false},
+	}
+
+	for i, tt := range tests {
+		name := fmt.Sprintf("%v", i)
+		t.Run(name, func(t *testing.T) {
+			v := New()
+			v.Required(name, tt.a)
+			if got := v.HasErrors(); got != tt.want {
+				t.Errorf("\ngot:  %#v\nwant: %#v\n", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestMerge(t *testing.T) {
 	tests := []struct {
 		a, b, want map[string][]string


### PR DESCRIPTION
`v.Required` falsely marks as valid when `int64` is passed.

This can easily be verified by running the test added against the current `master` branch.