### PR TITLE
Use string for sub-validation keys

### DIFF
--- a/validate.go
+++ b/validate.go
@@ -112,7 +112,7 @@ func (v *Validator) ErrorOrNil() error {
 
 // Sub allows to specific sub-validations.
 //
-// Errors from the subvalidation is merged with the top-level one, the keys are
+// Errors from the subvalidation are merged with the top-level one, the keys are
 // added as "top.sub" or "top[n].sub".
 //
 // If the error is not a Validator the text will be added as just the key name
@@ -130,13 +130,13 @@ func (v *Validator) ErrorOrNil() error {
 //   for i, a := range customer.Addresses {
 //       a.Sub("addresses", i, c.Validate())
 //   }
-func (v *Validator) Sub(key string, n int, err error) {
+func (v *Validator) Sub(key, subKey string, err error) {
 	if err == nil {
 		return
 	}
 
-	if n > -1 {
-		key = fmt.Sprintf("%s[%d]", key, n)
+	if subKey != "" {
+		key = fmt.Sprintf("%s[%s]", key, subKey)
 	}
 
 	sub, ok := err.(*Validator)

--- a/validate_test.go
+++ b/validate_test.go
@@ -95,44 +95,44 @@ func TestSub(t *testing.T) {
 		s := New()
 		s.Required("domain", "")
 		s.Email("contactEmail", "not an email")
-		v.Sub("setting", -1, s.ErrorOrNil())
+		v.Sub("setting", "", s.ErrorOrNil())
 
 		// List
 		addr1 := New()
 		addr1.Required("city", "Bristol")
-		v.Sub("addresses", 0, addr1)
+		v.Sub("addresses", "home", addr1)
 		addr2 := New()
 		addr2.Required("city", "")
-		v.Sub("addresses", 1, addr2)
+		v.Sub("addresses", "office", addr2)
 
 		// Non-Validator.
-		v.Sub("other", -1, errors.New("oh noes"))
-		v.Sub("emails", 0, nil)
-		v.Sub("emails", 1, errors.New("not an email"))
+		v.Sub("other", "", errors.New("oh noes"))
+		v.Sub("emails", "home", nil)
+		v.Sub("emails", "office", errors.New("not an email"))
 
 		// Sub with Sub.
 		s1 := New()
 		s2 := New()
 		s2.Append("err", "very sub")
-		s1.Sub("sub2", -1, s2)
-		v.Sub("sub1", -1, s1)
+		s1.Sub("sub2", "", s2)
+		v.Sub("sub1", "", s1)
 
 		ls1 := New()
 		ls2 := New()
 		ls2.Append("err", "very sub")
-		ls1.Sub("lsub2", 3, ls2)
-		v.Sub("lsub1", -1, ls1)
+		ls1.Sub("lsub2", "holiday", ls2)
+		v.Sub("lsub1", "", ls1)
 
 		want := map[string][]string{
-			"lsub1.lsub2[3].err":   []string{"very sub"},
-			"sub1.sub2.err":        []string{"very sub"},
-			"name":                 []string{"must be set"},
-			"color":                []string{"must be a valid color code"},
-			"setting.domain":       []string{"must be set"},
-			"setting.contactEmail": []string{"must be a valid email address"},
-			"addresses[1].city":    []string{"must be set"},
-			"other":                []string{"oh noes"},
-			"emails[1]":            []string{"not an email"},
+			"lsub1.lsub2[holiday].err": []string{"very sub"},
+			"sub1.sub2.err":            []string{"very sub"},
+			"name":                     []string{"must be set"},
+			"color":                    []string{"must be a valid color code"},
+			"setting.domain":           []string{"must be set"},
+			"setting.contactEmail":     []string{"must be a valid email address"},
+			"addresses[office].city":   []string{"must be set"},
+			"other":                    []string{"oh noes"},
+			"emails[office]":           []string{"not an email"},
 		}
 
 		if d := cmp.Diff(v.Errors, want); d != "" {


### PR DESCRIPTION
int works well, but just for arrays. Not for map[sting]...-type of
relations.

String is more flexible, and works for both.