### PR TITLE
Update Len() validation to support multiple input types

### DIFF
--- a/bin/lint
+++ b/bin/lint
@@ -62,7 +62,7 @@ gometalinter --deadline=240s --vendor --sort=path --tests --disable-all \
 	--enable=varcheck \
 	--enable=structcheck \
 	--enable=errcheck \
-	--enable=megacheck \
+	--enable=staticcheck \
 	--enable=ineffassign \
 	--enable=unconvert \
 	--enable=goconst \

--- a/messages.go
+++ b/messages.go
@@ -2,20 +2,21 @@ package validate
 
 // Messages for the checkers; this can be changed for i18n.
 var (
-	MessageRequired   = "must be set"
-	MessageDomain     = "must be a valid domain"
-	MessageURL        = "must be a valid url"
-	MessageEmail      = "must be a valid email address"
-	MessageIPv4       = "must be a valid IPv4 address"
-	MessageHexColor   = "must be a valid color code"
-	MessageLenLonger  = "must be longer than %d characters"
-	MessageLenShorter = "must be shorter than %d characters"
-	MessageExclude    = "cannot be ‘%s’"
-	MessageInclude    = "must be one of ‘%s’"
-	MessageInteger    = "must be a whole number"
-	MessageBool       = "must be a boolean"
-	MessageDate       = "must be a date as ‘%s’"
-	MessagePhone      = "must be a valid phone number"
+	MessageRequired       = "must be set"
+	MessageDomain         = "must be a valid domain"
+	MessageURL            = "must be a valid url"
+	MessageEmail          = "must be a valid email address"
+	MessageIPv4           = "must be a valid IPv4 address"
+	MessageHexColor       = "must be a valid color code"
+	MessageLenLonger      = "must be longer than %d"
+	MessageLenShorter     = "must be shorter than %d"
+	MessageLenInvalidType = "cannot validate length of type %s"
+	MessageExclude        = "cannot be ‘%s’"
+	MessageInclude        = "must be one of ‘%s’"
+	MessageInteger        = "must be a whole number"
+	MessageBool           = "must be a boolean"
+	MessageDate           = "must be a date as ‘%s’"
+	MessagePhone          = "must be a valid phone number"
 )
 
 func getMessage(in []string, def string) string {

--- a/validate_test.go
+++ b/validate_test.go
@@ -286,7 +286,7 @@ func TestValidators(t *testing.T) {
 			make(map[string][]string),
 		},
 
-		// Len
+		// Len - string
 		{
 			func(v Validator) { v.Len("v", "w00t", 2, 5) },
 			make(map[string][]string),
@@ -301,7 +301,7 @@ func TestValidators(t *testing.T) {
 		},
 		{
 			func(v Validator) { v.Len("v", "w00t", 1, 2) },
-			map[string][]string{"v": {"must be shorter than 2 characters"}},
+			map[string][]string{"v": {"must be shorter than 2"}},
 		},
 		{
 			func(v Validator) { v.Len("v", "w00t", 1, 2, "foo") },
@@ -309,7 +309,162 @@ func TestValidators(t *testing.T) {
 		},
 		{
 			func(v Validator) { v.Len("v", "w00t", 16, 32) },
-			map[string][]string{"v": {"must be longer than 16 characters"}},
+			map[string][]string{"v": {"must be longer than 16"}},
+		},
+		{
+			func(v Validator) { v.Len("v", "w00t", 16, 32, "foo") },
+			map[string][]string{"v": {"foo"}},
+		},
+
+		// Len - slice
+		{
+			func(v Validator) { v.Len("foo", []int{1, 2}, 1, 3) },
+			map[string][]string{},
+		},
+		{
+			func(v Validator) { v.Len("foo", []int{1, 2}, 0, 3) },
+			map[string][]string{},
+		},
+		{
+			func(v Validator) { v.Len("foo", []int{1, 2}, 2, 0) },
+			map[string][]string{},
+		},
+		{
+			func(v Validator) { v.Len("foo", []int{}, 1, 0, "msg") },
+			map[string][]string{"foo": []string{"msg"}},
+		},
+		{
+			func(v Validator) { v.Len("foo", []int{}, 1, 0) },
+			map[string][]string{"foo": []string{"must be longer than 1"}},
+		},
+		{
+			func(v Validator) { v.Len("foo", []int{3, 4}, 0, 1, "msg") },
+			map[string][]string{"foo": []string{"msg"}},
+		},
+		{
+			func(v Validator) { v.Len("foo", []int{3, 4}, 0, 1) },
+			map[string][]string{"foo": []string{"must be shorter than 1"}},
+		},
+
+		// Len - map
+		{
+			func(v Validator) { v.Len("foo", map[int]int{1: 1, 2: 2}, 1, 3) },
+			map[string][]string{},
+		},
+		{
+			func(v Validator) { v.Len("foo", map[int]int{1: 1, 2: 2}, 0, 3) },
+			map[string][]string{},
+		},
+		{
+			func(v Validator) { v.Len("foo", map[int]int{1: 1, 2: 2}, 2, 0) },
+			map[string][]string{},
+		},
+		{
+			func(v Validator) { v.Len("foo", map[int]int{}, 1, 0, "msg") },
+			map[string][]string{"foo": []string{"msg"}},
+		},
+		{
+			func(v Validator) { v.Len("foo", map[int]int{}, 1, 0) },
+			map[string][]string{"foo": []string{"must be longer than 1"}},
+		},
+		{
+			func(v Validator) { v.Len("foo", map[int]int{1: 1, 2: 2}, 0, 1, "msg") },
+			map[string][]string{"foo": []string{"msg"}},
+		},
+		{
+			func(v Validator) { v.Len("foo", map[int]int{1: 1, 2: 2}, 0, 1) },
+			map[string][]string{"foo": []string{"must be shorter than 1"}},
+		},
+
+		// Len - array
+		{
+			func(v Validator) { v.Len("foo", [2]int{}, 1, 3) },
+			map[string][]string{},
+		},
+		{
+			func(v Validator) { v.Len("foo", [2]int{}, 0, 3) },
+			map[string][]string{},
+		},
+		{
+			func(v Validator) { v.Len("foo", [2]int{}, 2, 0) },
+			map[string][]string{},
+		},
+		{
+			func(v Validator) { v.Len("foo", [0]int{}, 1, 0, "msg") },
+			map[string][]string{"foo": []string{"msg"}},
+		},
+		{
+			func(v Validator) { v.Len("foo", [0]int{}, 1, 0) },
+			map[string][]string{"foo": []string{"must be longer than 1"}},
+		},
+		{
+			func(v Validator) { v.Len("foo", [2]int{}, 0, 1, "msg") },
+			map[string][]string{"foo": []string{"msg"}},
+		},
+		{
+			func(v Validator) { v.Len("foo", [2]int{}, 0, 1) },
+			map[string][]string{"foo": []string{"must be shorter than 1"}},
+		},
+
+		// Len - channel
+		{
+			func(v Validator) {
+				c := make(chan int, 3)
+				c <- 1
+				c <- 2
+				v.Len("foo", c, 1, 3)
+			},
+			map[string][]string{},
+		},
+		{
+			func(v Validator) {
+				c := make(chan int, 3)
+				c <- 1
+				c <- 2
+				v.Len("foo", c, 0, 3)
+			},
+			map[string][]string{},
+		},
+		{
+			func(v Validator) {
+				c := make(chan int, 3)
+				c <- 1
+				c <- 2
+				v.Len("foo", c, 2, 0)
+			},
+			map[string][]string{},
+		},
+		{
+			func(v Validator) { v.Len("foo", make(chan int), 1, 0, "msg") },
+			map[string][]string{"foo": []string{"msg"}},
+		},
+		{
+			func(v Validator) { v.Len("foo", make(chan int), 1, 0) },
+			map[string][]string{"foo": []string{"must be longer than 1"}},
+		},
+		{
+			func(v Validator) {
+				c := make(chan int, 3)
+				c <- 1
+				c <- 2
+				v.Len("foo", c, 0, 1, "msg")
+			},
+			map[string][]string{"foo": []string{"msg"}},
+		},
+		{
+			func(v Validator) {
+				c := make(chan int, 3)
+				c <- 1
+				c <- 2
+				v.Len("foo", c, 0, 1)
+			},
+			map[string][]string{"foo": []string{"must be shorter than 1"}},
+		},
+
+		// Len - invalid
+		{
+			func(v Validator) { v.Len("foo", 1, 0, 0, "msg") },
+			map[string][]string{"foo": []string{"cannot validate length of type int"}},
 		},
 
 		// Exclude


### PR DESCRIPTION
This PR updates the `Len()` validation to work with other types other than string as input.

Changing the input type to `interface{}` should not bring breaking changes. However, the error messages were changed since they are not string specific anymore. If any party uses these messages for error handling for example, then it should be considered as breaking change.
