### PR TITLE
Validate length of multibyte characters better

### DIFF
--- a/validate.go
+++ b/validate.go
@@ -52,6 +52,7 @@ import (
 	"strconv"
 	"strings"
 	"time"
+	"unicode/utf8"
 
 	"github.com/teamwork/mailaddress"
 )
@@ -439,16 +440,16 @@ func (v *Validator) HexColor(key, value string, message ...string) {
 func (v *Validator) Len(key, value string, min, max int, message ...string) {
 	msg := getMessage(message, "")
 
-	runeVal := []rune(value)
+	length := utf8.RuneCountInString(value)
 
 	switch {
-	case len(runeVal) < min:
+	case length < min:
 		if msg != "" {
 			v.Append(key, msg)
 		} else {
 			v.Append(key, fmt.Sprintf(MessageLenLonger, min))
 		}
-	case max > 0 && len(runeVal) > max:
+	case max > 0 && length > max:
 		if msg != "" {
 			v.Append(key, msg)
 		} else {

--- a/validate.go
+++ b/validate.go
@@ -439,14 +439,16 @@ func (v *Validator) HexColor(key, value string, message ...string) {
 func (v *Validator) Len(key, value string, min, max int, message ...string) {
 	msg := getMessage(message, "")
 
+	runeVal := []rune(value)
+
 	switch {
-	case len(value) < min:
+	case len(runeVal) < min:
 		if msg != "" {
 			v.Append(key, msg)
 		} else {
 			v.Append(key, fmt.Sprintf(MessageLenLonger, min))
 		}
-	case max > 0 && len(value) > max:
+	case max > 0 && len(runeVal) > max:
 		if msg != "" {
 			v.Append(key, msg)
 		} else {

--- a/validate.go
+++ b/validate.go
@@ -434,7 +434,8 @@ func (v *Validator) HexColor(key, value string, message ...string) {
 	}
 }
 
-// Len sets the minimum and maximum length for a string.
+// Len sets the minimum and maximum length for a string in characters, not in
+// bytes.
 //
 // A maximum of 0 indicates there is no upper limit.
 func (v *Validator) Len(key, value string, min, max int, message ...string) {

--- a/validate_test.go
+++ b/validate_test.go
@@ -311,7 +311,10 @@ func TestValidators(t *testing.T) {
 			func(v Validator) { v.Len("v", "w00t", 16, 32) },
 			map[string][]string{"v": {"must be longer than 16 characters"}},
 		},
-
+		{
+			func(v Validator) { v.Len("v", "ราคาเหนือจอง", 12, 12) },
+			make(map[string][]string),
+		},
 		// Exclude
 		{
 			func(v Validator) { v.Exclude("key", "val", []string{}) },


### PR DESCRIPTION
If we length check on just the string when there's some foreign characters in there it can often come back as a length you wouldn't expect. This doesn't make much sense to me for validation purposes, you always want the length of a string to mean x characters, not bytes.

See my Go Playground: https://play.golang.org/p/GNDIG2Tzx4y

I would expect the behaviour of the runed string, not the latter when validating.