### PR TITLE
Support Required for []int64

### DIFF
--- a/validate.go
+++ b/validate.go
@@ -230,6 +230,10 @@ func (v *Validator) Required(key string, value interface{}, message ...string) {
 		if len(val) == 0 {
 			v.Append(key, msg)
 		}
+	case []int64:
+		if len(val) == 0 {
+			v.Append(key, msg)
+		}
 	case []string:
 		if len(val) == 0 {
 			v.Append(key, msg)

--- a/validate_test.go
+++ b/validate_test.go
@@ -286,6 +286,23 @@ func TestValidators(t *testing.T) {
 			make(map[string][]string),
 		},
 
+		// []int64
+		{
+			func(v Validator) { v.Required("k", []int64{}) },
+			map[string][]string{"k": {"must be set"}},
+		},
+		{
+			func(v Validator) {
+				var val []int64
+				v.Required("k", val)
+			},
+			map[string][]string{"k": {"must be set"}},
+		},
+		{
+			func(v Validator) { v.Required("k", []int64{1, 2}) },
+			make(map[string][]string),
+		},
+
 		// Len
 		{
 			func(v Validator) { v.Len("v", "w00t", 2, 5) },


### PR DESCRIPTION
This PR adds support for the `[]int64` type in the `Required` validation.