### PR TITLE
Required: support *string

### DIFF
--- a/validate.go
+++ b/validate.go
@@ -202,6 +202,10 @@ func (v *Validator) Required(key string, value interface{}, message ...string) {
 		if strings.TrimSpace(val) == "" {
 			v.Append(key, msg)
 		}
+	case *string:
+		if val == nil || strings.TrimSpace(*val) == "" {
+			v.Append(key, msg)
+		}
 	case int:
 		if val == int(0) {
 			v.Append(key, msg)

--- a/validate_test.go
+++ b/validate_test.go
@@ -38,6 +38,32 @@ func TestRequiredInt(t *testing.T) {
 	}
 }
 
+func TestRequiredString(t *testing.T) {
+	empty := ""
+	nonEmpty := "test"
+
+	tests := []struct {
+		a    interface{}
+		want bool
+	}{
+		{empty, true},
+		{&empty, true},
+		{nonEmpty, false},
+		{&nonEmpty, false},
+	}
+
+	for i, tt := range tests {
+		name := fmt.Sprintf("%v", i)
+		t.Run(name, func(t *testing.T) {
+			v := New()
+			v.Required(name, tt.a)
+			if got := v.HasErrors(); got != tt.want {
+				t.Errorf("\ngot:  %#v\nwant: %#v\n", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestMerge(t *testing.T) {
 	tests := []struct {
 		a, b, want map[string][]string


### PR DESCRIPTION
We often have structs that have `*string` fields for mapping to nullable database columns and being able to validate without extra
```
if x == nil {
	v.Append(...)
} else {
	v.Required(...)
}
```
or wrapping with `ptr2str` funcs would be handy 😊 