### PR TITLE
required: support any pointer type

### DIFF
--- a/validate.go
+++ b/validate.go
@@ -47,6 +47,7 @@ import (
 	"fmt"
 	"net"
 	"net/url"
+	"reflect"
 	"regexp"
 	"sort"
 	"strconv"
@@ -257,6 +258,12 @@ func (v *Validator) Required(key string, value interface{}, message ...string) {
 			v.Append(key, msg)
 		}
 	default:
+		if vv := reflect.ValueOf(value); vv.Kind() == reflect.Ptr {
+			if value == reflect.Zero(vv.Type()).Interface() {
+				v.Append(key, msg)
+			}
+			return
+		}
 		panic(fmt.Sprintf("validate: not a supported type: %T", value))
 	}
 }

--- a/validate_test.go
+++ b/validate_test.go
@@ -64,6 +64,34 @@ func TestRequiredString(t *testing.T) {
 	}
 }
 
+func TestRequiredPtr(t *testing.T) {
+	type customStruct struct {
+		String string
+		Int    int
+	}
+	var empty *customStruct
+	nonEmpty := &customStruct{}
+
+	tests := []struct {
+		a    interface{}
+		want bool
+	}{
+		{empty, true},
+		{nonEmpty, false},
+	}
+
+	for i, tt := range tests {
+		name := fmt.Sprintf("%v", i)
+		t.Run(name, func(t *testing.T) {
+			v := New()
+			v.Required(name, tt.a)
+			if got := v.HasErrors(); got != tt.want {
+				t.Errorf("\ngot:  %#v\nwant: %#v\n", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestMerge(t *testing.T) {
 	tests := []struct {
 		a, b, want map[string][]string


### PR DESCRIPTION
Allow Required to shallow verify any pointer, useful for some pre validations
```go
type SomeRequest struct {
   Message *Content
}
// ...
v.Required("Message", r.Message)
```
