### PR TITLE
show value received in error

### DIFF
--- a/messages.go
+++ b/messages.go
@@ -11,7 +11,7 @@ var (
 	MessageLenLonger   = "must be longer than %d characters"
 	MessageLenShorter  = "must be shorter than %d characters"
 	MessageExclude     = "cannot be ‘%s’"
-	MessageInclude     = "must be one of ‘%s’"
+	MessageInclude     = "must be one of ‘%s’; got ‘%s’"
 	MessageInteger     = "must be a whole number"
 	MessageBool        = "must be a boolean"
 	MessageDate        = "must be a date as ‘%s’"

--- a/validate.go
+++ b/validate.go
@@ -2,44 +2,44 @@
 //
 // Basic usage example:
 //
-//   v := validate.New()
-//   v.Required("firstName", customer.FirstName)
-//   if v.HasErrors() {
-//       fmt.Println("Had the following validation errors:")
-//       for key, errors := range v.Errors {
-//           fmt.Printf("    %s: %s", key, strings.Join(errors))
-//       }
-//   }
+//	v := validate.New()
+//	v.Required("firstName", customer.FirstName)
+//	if v.HasErrors() {
+//	    fmt.Println("Had the following validation errors:")
+//	    for key, errors := range v.Errors {
+//	        fmt.Printf("    %s: %s", key, strings.Join(errors))
+//	    }
+//	}
 //
 // All validators treat the input's zero type (empty string, 0, nil, etc.) as
 // valid. Use the Required() validator if you want to make a parameter required.
 //
 // All validators optionally accept a custom message as the last parameter:
 //
-//   v.Required("key", value, "you really need to set this")
+//	v.Required("key", value, "you really need to set this")
 //
 // The error text only includes a simple human description such as "must be set"
 // or "must be a valid email". When adding new validations, make sure that they
 // can be displayed properly when joined with commas. A text such as "Error:
 // this field must be higher than 42" would look weird:
 //
-//   must be set, Error: this field must be higher than 42
+//	must be set, Error: this field must be higher than 42
 //
 // You can set your own errors with v.Append():
 //
-//   if !condition {
-//       v.Append("key", "must be a valid foo")
-//   }
+//	if !condition {
+//	    v.Append("key", "must be a valid foo")
+//	}
 //
 // Some validators return the parsed value, which makes it easier both validate
 // and get a useful value at the same time:
 //
-//   v := validate.New()
-//   id := v.Integer("id", c.Param("id"))
-//   if v.HasErrors() {
-//       return v
-//   }
-//   user := getUserByID(id)
+//	v := validate.New()
+//	id := v.Integer("id", c.Param("id"))
+//	if v.HasErrors() {
+//	    return v
+//	}
+//	user := getUserByID(id)
 package validate // import "github.com/teamwork/validate"
 
 import (
@@ -96,14 +96,14 @@ func (v *Validator) HasErrors() bool {
 //
 // This makes it a bit more elegant to return from a function:
 //
-//   if v.HasErrors() {
-//       return v
-//   }
-//   return nil
+//	if v.HasErrors() {
+//	    return v
+//	}
+//	return nil
 //
 // Can now be:
 //
-//   return v.ErrorOrNil()
+//	return v.ErrorOrNil()
 func (v *Validator) ErrorOrNil() error {
 	if v.HasErrors() {
 		return v
@@ -121,16 +121,16 @@ func (v *Validator) ErrorOrNil() error {
 //
 // For example:
 //
-//   v := validate.New()
-//   v.Required("name", customer.Name)
+//	v := validate.New()
+//	v.Required("name", customer.Name)
 //
-//   // e.g. "settings.domain"
-//   v.Sub("settings", -1, customer.Settings.Validate())
+//	// e.g. "settings.domain"
+//	v.Sub("settings", -1, customer.Settings.Validate())
 //
-//   // e.g. "addresses[1].city"
-//   for i, a := range customer.Addresses {
-//       a.Sub("addresses", i, c.Validate())
-//   }
+//	// e.g. "addresses[1].city"
+//	for i, a := range customer.Addresses {
+//	    a.Sub("addresses", i, c.Validate())
+//	}
 func (v *Validator) Sub(key, subKey string, err error) {
 	if err == nil {
 		return
@@ -304,7 +304,7 @@ func (v *Validator) IncludeInt64(key string, value int64, include []int64, messa
 		for _, e := range include {
 			intStr = append(intStr, strconv.FormatInt(e, 10))
 		}
-		v.Append(key, fmt.Sprintf(MessageInclude, strings.Join(intStr, ", ")))
+		v.Append(key, fmt.Sprintf(MessageInclude, strings.Join(intStr, ", "), strconv.FormatInt(value, 10)))
 	}
 }
 
@@ -370,7 +370,7 @@ func (v *Validator) Include(key, value string, include []string, message ...stri
 	if msg != "" {
 		v.Append(key, msg)
 	} else {
-		v.Append(key, fmt.Sprintf(MessageInclude, strings.Join(include, ", ")))
+		v.Append(key, fmt.Sprintf(MessageInclude, strings.Join(include, ", "), value))
 	}
 }
 
@@ -399,7 +399,7 @@ func (v *Validator) IncludeWithSanitization(
 	if message != "" {
 		v.Append(key, message)
 	} else {
-		v.Append(key, fmt.Sprintf(MessageInclude, strings.Join(include, ", ")))
+		v.Append(key, fmt.Sprintf(MessageInclude, strings.Join(include, ", "), value))
 	}
 }
 

--- a/validate_test.go
+++ b/validate_test.go
@@ -206,15 +206,15 @@ func TestSub(t *testing.T) {
 		v.Sub("lsub1", "", ls1)
 
 		want := map[string][]string{
-			"lsub1.lsub2[holiday].err": []string{"very sub"},
-			"sub1.sub2.err":            []string{"very sub"},
-			"name":                     []string{"must be set"},
-			"color":                    []string{"must be a valid color code"},
-			"setting.domain":           []string{"must be set"},
-			"setting.contactEmail":     []string{"must be a valid email address"},
-			"addresses[office].city":   []string{"must be set"},
-			"other":                    []string{"oh noes"},
-			"emails[office]":           []string{"not an email"},
+			"lsub1.lsub2[holiday].err": {"very sub"},
+			"sub1.sub2.err":            {"very sub"},
+			"name":                     {"must be set"},
+			"color":                    {"must be a valid color code"},
+			"setting.domain":           {"must be set"},
+			"setting.contactEmail":     {"must be a valid email address"},
+			"addresses[office].city":   {"must be set"},
+			"other":                    {"oh noes"},
+			"emails[office]":           {"not an email"},
 		}
 
 		if d := cmp.Diff(v.Errors, want); d != "" {
@@ -448,7 +448,7 @@ func TestValidators(t *testing.T) {
 		},
 		{
 			func(v Validator) { v.IncludeInt64("key", 1, []int64{2}) },
-			map[string][]string{"key": {`must be one of ‘2’`}},
+			map[string][]string{"key": {`must be one of ‘2’; got ‘1’`}},
 		},
 		{
 			func(v Validator) { v.IncludeInt64("key", 1, []int64{2}, "foo") },
@@ -528,7 +528,7 @@ func TestValidators(t *testing.T) {
 		},
 		{
 			func(v Validator) { v.Include("key", "val", []string{"valx"}) },
-			map[string][]string{"key": {`must be one of ‘valx’`}},
+			map[string][]string{"key": {`must be one of ‘valx’; got ‘val’`}},
 		},
 		{
 			func(v Validator) { v.Include("key", "val", []string{"valx"}, "foo") },
@@ -554,7 +554,7 @@ func TestValidators(t *testing.T) {
 		},
 		{
 			func(v Validator) { v.IncludeWithSanitization("key", "val", []string{"valx"}, "") },
-			map[string][]string{"key": {`must be one of ‘valx’`}},
+			map[string][]string{"key": {`must be one of ‘valx’; got ‘val’`}},
 		},
 		{
 			func(v Validator) { v.IncludeWithSanitization("key", "val", []string{"valx"}, "foo") },
@@ -572,7 +572,7 @@ func TestValidators(t *testing.T) {
 			func(v Validator) {
 				v.IncludeWithSanitization("key", "val", []string{"hello", "val "}, "", strings.TrimSpace)
 			},
-			map[string][]string{"key": {"must be one of ‘hello, val ’"}},
+			map[string][]string{"key": {"must be one of ‘hello, val ’; got ‘val’"}},
 		},
 		{
 			func(v Validator) {


### PR DESCRIPTION
While working on some tests I noticed that when using `Include` you don't get the value that was being passed in to the validator so it can be difficult to tell if you just sent it an empty value or just the value was wrong.  This adds a `got "x"` suffix to the string.